### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   extension-ci:
     uses: steadybit/extension-kit/.github/workflows/reusable-extension-ci.yml@main # NOSONAR githubactions:S7637 - our own action
     with:
-      go_version: '^1.25.9'
+      go_version: '^1.26.2'
       build_linux_packages: false
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Bump Go to 1.26.2
+
 ## v1.0.43
 
 - Bump Go to 1.25.9

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/steadybit/action-kit/go/action_kit_test/e2e"
 	"github.com/steadybit/discovery-kit/go/discovery_kit_test/validate"
 	"github.com/steadybit/extension-kit/extlogging"
-	"github.com/steadybit/extension-kit/extutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -165,7 +164,7 @@ func readFileContent(t *testing.T, filePath string) string {
 
 func testRunGatling(t *testing.T, m *e2e.Minikube, e *e2e.Extension, fileName string, filePath string) {
 	config := struct{}{}
-	context := &action_kit_api.ExecutionContext{ExperimentKey: extutil.Ptr("ADM-1"), ExecutionId: extutil.Ptr(4711)}
+	context := &action_kit_api.ExecutionContext{ExperimentKey: new("ADM-1"), ExecutionId: new(4711)}
 	content := readFileContent(t, filePath)
 	files := []client.File{
 		{
@@ -205,7 +204,7 @@ func testRunGatlingEnterpriseSimulation(t *testing.T, m *e2e.Minikube, e *e2e.Ex
 			"gatling.simulation.id": {simulationId},
 		},
 	}
-	context := &action_kit_api.ExecutionContext{ExperimentKey: extutil.Ptr("ADM-1"), ExecutionId: extutil.Ptr(4711)}
+	context := &action_kit_api.ExecutionContext{ExperimentKey: new("ADM-1"), ExecutionId: new(4711)}
 
 	exec, err := e.RunAction("com.steadybit.extension_gatling.enterprise.run", &target, config, context)
 	require.NoError(t, err)

--- a/extgatling/discovery.go
+++ b/extgatling/discovery.go
@@ -10,7 +10,6 @@ import (
 	"github.com/steadybit/discovery-kit/go/discovery_kit_sdk"
 	"github.com/steadybit/extension-gatling/config"
 	"github.com/steadybit/extension-kit/extbuild"
-	"github.com/steadybit/extension-kit/extutil"
 	"os"
 )
 
@@ -32,7 +31,7 @@ func (e *gatlingLocationDiscovery) Describe() discovery_kit_api.DiscoveryDescrip
 	return discovery_kit_api.DiscoveryDescription{
 		Id: targetType,
 		Discover: discovery_kit_api.DescribingEndpointReferenceWithCallInterval{
-			CallInterval: extutil.Ptr(fmt.Sprintf("%ds", 300)),
+			CallInterval: new(fmt.Sprintf("%ds", 300)),
 		},
 	}
 }
@@ -41,9 +40,9 @@ func (e *gatlingLocationDiscovery) DescribeTarget() discovery_kit_api.TargetDesc
 	return discovery_kit_api.TargetDescription{
 		Id:       targetType,
 		Label:    discovery_kit_api.PluralLabel{One: "Gatling Location", Other: "Gatling Locations"},
-		Category: extutil.Ptr("execution locations"),
+		Category: new("execution locations"),
 		Version:  extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:     extutil.Ptr(targetIcon),
+		Icon:     new(targetIcon),
 
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{

--- a/extgatling/run.go
+++ b/extgatling/run.go
@@ -56,8 +56,8 @@ func (l *GatlingLoadTestRunAction) Describe() action_kit_api.ActionDescription {
 		Label:       "Gatling",
 		Description: "Execute a Gatling load test.",
 		Version:     extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:        extutil.Ptr(actionIcon),
-		Technology:  extutil.Ptr("Gatling"),
+		Icon:        new(actionIcon),
+		Technology:  new("Gatling"),
 		Kind:        action_kit_api.LoadTest,
 		TimeControl: action_kit_api.TimeControlInternal,
 		Hint: &action_kit_api.ActionHint{
@@ -68,10 +68,10 @@ func (l *GatlingLoadTestRunAction) Describe() action_kit_api.ActionDescription {
 			{
 				Name:        "file",
 				Label:       "Gatling Sources",
-				Description: extutil.Ptr("Upload your Gatling Sources. zip files will be extracted."),
+				Description: new("Upload your Gatling Sources. zip files will be extracted."),
 				Type:        action_kit_api.ActionParameterTypeFile,
-				Required:    extutil.Ptr(true),
-				AcceptedFileTypes: extutil.Ptr([]string{
+				Required:    new(true),
+				AcceptedFileTypes: new([]string{
 					".zip",
 					".java",
 					".scala",
@@ -81,22 +81,22 @@ func (l *GatlingLoadTestRunAction) Describe() action_kit_api.ActionDescription {
 			{
 				Name:        "parameter",
 				Label:       "Parameter",
-				Description: extutil.Ptr("Parameters will be accessible from your Gatling Source via Java System Properties, e.g. System.getProperty(\"myParameter\")"),
+				Description: new("Parameters will be accessible from your Gatling Source via Java System Properties, e.g. System.getProperty(\"myParameter\")"),
 				Type:        action_kit_api.ActionParameterTypeKeyValue,
-				Required:    extutil.Ptr(false),
+				Required:    new(false),
 			},
 			{
 				Name:        "simulation",
 				Label:       "Simulation",
-				Description: extutil.Ptr("ClassName of the Simulation to execute. Can be omitted if there is only one simulation in the source files."),
+				Description: new("ClassName of the Simulation to execute. Can be omitted if there is only one simulation in the source files."),
 				Type:        action_kit_api.ActionParameterTypeString,
-				Required:    extutil.Ptr(false),
+				Required:    new(false),
 			},
 		},
-		Status: extutil.Ptr(action_kit_api.MutatingEndpointReferenceWithCallInterval{
-			CallInterval: extutil.Ptr("5s"),
+		Status: new(action_kit_api.MutatingEndpointReferenceWithCallInterval{
+			CallInterval: new("5s"),
 		}),
-		Stop: extutil.Ptr(action_kit_api.MutatingEndpointReference{}),
+		Stop: new(action_kit_api.MutatingEndpointReference{}),
 	}
 
 	if config.Config.EnableLocationSelection {
@@ -104,11 +104,11 @@ func (l *GatlingLoadTestRunAction) Describe() action_kit_api.ActionDescription {
 			Name:  "-",
 			Label: "Filter Gatling Locations",
 			Type:  action_kit_api.ActionParameterTypeTargetSelection,
-			Order: extutil.Ptr(3),
+			Order: new(3),
 		})
-		description.TargetSelection = extutil.Ptr(action_kit_api.TargetSelection{
+		description.TargetSelection = new(action_kit_api.TargetSelection{
 			TargetType: targetType,
-			DefaultBlastRadius: extutil.Ptr(action_kit_api.DefaultBlastRadius{
+			DefaultBlastRadius: new(action_kit_api.DefaultBlastRadius{
 				Mode:  action_kit_api.DefaultBlastRadiusModeMaximum,
 				Value: 1,
 			}),
@@ -283,7 +283,7 @@ func (l *GatlingLoadTestRunAction) Status(_ context.Context, state *GatlingLoadT
 	messages := stdOutToMessages(stdOut)
 	log.Debug().Msgf("Returning %d messages", len(messages))
 
-	result.Messages = extutil.Ptr(messages)
+	result.Messages = new(messages)
 	return &result, nil
 }
 
@@ -363,8 +363,8 @@ func (l *GatlingLoadTestRunAction) Stop(_ context.Context, state *GatlingLoadTes
 
 	log.Debug().Msgf("Returning %d messages", len(messages))
 	return &action_kit_api.StopResult{
-		Artifacts: extutil.Ptr(artifacts),
-		Messages:  extutil.Ptr(messages),
+		Artifacts: new(artifacts),
+		Messages:  new(messages),
 		Error:     resultErr,
 	}, nil
 }

--- a/extgatling/run_test.go
+++ b/extgatling/run_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"github.com/google/uuid"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
-	"github.com/steadybit/extension-kit/extutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -158,14 +157,14 @@ func TestPrepare(t *testing.T) {
 	// Create a minimal prepare request
 	request := action_kit_api.PrepareActionRequestBody{
 		ExecutionId: execId,
-		Config: map[string]interface{}{
+		Config: map[string]any{
 			"file":       "/tmp/test.scala",
 			"parameter":  []map[string]string{{"key": "users", "value": "10"}},
 			"simulation": "TestSimulation",
 		},
 		ExecutionContext: &action_kit_api.ExecutionContext{
-			ExperimentKey: extutil.Ptr("test-experiment"),
-			ExecutionId:   extutil.Ptr(1),
+			ExperimentKey: new("test-experiment"),
+			ExecutionId:   new(1),
 		},
 	}
 
@@ -182,4 +181,3 @@ func TestPrepare(t *testing.T) {
 		t.Logf("Prepare error (expected): %v", err)
 	}
 }
-

--- a/extgatlingenterprise/action_run.go
+++ b/extgatlingenterprise/action_run.go
@@ -49,12 +49,12 @@ func (f RunAction) Describe() action_kit_api.ActionDescription {
 		Description: "Run a simulation via Gatling Enterprise",
 		Version:     extbuild.GetSemverVersionStringOrUnknown(),
 		Kind:        action_kit_api.LoadTest,
-		Icon:        extutil.Ptr(actionIcon),
-		Technology:  extutil.Ptr("Gatling"),
-		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
+		Icon:        new(actionIcon),
+		Technology:  new("Gatling"),
+		TargetSelection: new(action_kit_api.TargetSelection{
 			TargetType:          targetType,
 			QuantityRestriction: extutil.Ptr(action_kit_api.QuantityRestrictionExactlyOne),
-			SelectionTemplates: extutil.Ptr([]action_kit_api.TargetSelectionTemplate{
+			SelectionTemplates: new([]action_kit_api.TargetSelectionTemplate{
 				{
 					Label: "simulation name",
 					Query: "gatling.simulation.name=\"\"",
@@ -66,33 +66,33 @@ func (f RunAction) Describe() action_kit_api.ActionDescription {
 			{
 				Name:         "duration",
 				Label:        "Estimated duration",
-				DefaultValue: extutil.Ptr("30s"),
-				Description:  extutil.Ptr("The step will run as long as needed. You can set this estimation to size the step in the experiment editor for a better understanding of the time schedule."),
-				Required:     extutil.Ptr(true),
+				DefaultValue: new("30s"),
+				Description:  new("The step will run as long as needed. You can set this estimation to size the step in the experiment editor for a better understanding of the time schedule."),
+				Required:     new(true),
 				Type:         action_kit_api.ActionParameterTypeDuration,
 			},
 			{
 				Name:        "systemProperties",
 				Label:       "Java System Properties",
-				Description: extutil.Ptr("Java System Properties passed to the simulation"),
+				Description: new("Java System Properties passed to the simulation"),
 				Type:        action_kit_api.ActionParameterTypeKeyValue,
-				Required:    extutil.Ptr(false),
-				Advanced:    extutil.Ptr(true),
+				Required:    new(false),
+				Advanced:    new(true),
 			},
 			{
 				Name:        "environmentVariables",
 				Label:       "Environment variables",
-				Description: extutil.Ptr("Environment variables passed to the simulation"),
+				Description: new("Environment variables passed to the simulation"),
 				Type:        action_kit_api.ActionParameterTypeKeyValue,
-				Required:    extutil.Ptr(false),
-				Advanced:    extutil.Ptr(true),
+				Required:    new(false),
+				Advanced:    new(true),
 			},
 		},
 		Prepare: action_kit_api.MutatingEndpointReference{},
 		Start:   action_kit_api.MutatingEndpointReference{},
-		Status:  extutil.Ptr(action_kit_api.MutatingEndpointReferenceWithCallInterval{}),
-		Stop:    extutil.Ptr(action_kit_api.MutatingEndpointReference{}),
-		Widgets: extutil.Ptr([]action_kit_api.Widget{
+		Status:  new(action_kit_api.MutatingEndpointReferenceWithCallInterval{}),
+		Stop:    new(action_kit_api.MutatingEndpointReference{}),
+		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.MarkdownWidget{
 				Type:        action_kit_api.ComSteadybitWidgetMarkdown,
 				Title:       "Gatling Enterprise",
@@ -149,15 +149,15 @@ func (f RunAction) Start(_ context.Context, state *RunState) (*action_kit_api.St
 		messages = []action_kit_api.Message{
 			{
 				Message: fmt.Sprintf("[Open Summary](https://cloud.gatling.io/o/%s/simulations/%s/runs/%s)", config.Config.EnterpriseOrganizationSlug, state.SimulationId, state.RunId),
-				Type:    extutil.Ptr("GATLING"),
+				Type:    new("GATLING"),
 			},
 			{
 				Message: fmt.Sprintf("[Open Report](https://cloud.gatling.io/o/%s/simulations/%s/runs/%s/details)", config.Config.EnterpriseOrganizationSlug, state.SimulationId, state.RunId),
-				Type:    extutil.Ptr("GATLING"),
+				Type:    new("GATLING"),
 			},
 			{
 				Message: fmt.Sprintf("[Open Logs](https://cloud.gatling.io/o/%s/simulations/%s/runs/%s/logs)", config.Config.EnterpriseOrganizationSlug, state.SimulationId, state.RunId),
-				Type:    extutil.Ptr("GATLING"),
+				Type:    new("GATLING"),
 			},
 		}
 	}
@@ -180,14 +180,14 @@ func (f RunAction) Status(_ context.Context, state *RunState) (*action_kit_api.S
 
 	if state.LastState != run.Status {
 		log.Info().Str("state", statusToString(run.Status)).Msg("Simulation state changed")
-		result.Messages = extutil.Ptr([]action_kit_api.Message{
+		result.Messages = new([]action_kit_api.Message{
 			{
 				Level:   extutil.Ptr(action_kit_api.Info),
 				Message: fmt.Sprintf("Simulation state: %s", statusToString(run.Status)),
 			},
 			{
 				Message: "- " + statusToString(run.Status) + appendDots(run.Status),
-				Type:    extutil.Ptr("GATLING"),
+				Type:    new("GATLING"),
 			},
 		})
 		state.LastState = run.Status
@@ -281,7 +281,7 @@ func (f RunAction) Stop(_ context.Context, state *RunState) (*action_kit_api.Sto
 	if len(run.Assertions) > 0 {
 		messages = append(messages, action_kit_api.Message{
 			Message: "### Assertions",
-			Type:    extutil.Ptr("GATLING"),
+			Type:    new("GATLING"),
 		})
 		for _, assertion := range run.Assertions {
 			icon := "❌"
@@ -290,7 +290,7 @@ func (f RunAction) Stop(_ context.Context, state *RunState) (*action_kit_api.Sto
 			}
 			messages = append(messages, action_kit_api.Message{
 				Message: fmt.Sprintf("- %s %s (%.0f)", icon, assertion.Message, assertion.ActualValue),
-				Type:    extutil.Ptr("GATLING"),
+				Type:    new("GATLING"),
 			})
 		}
 	}
@@ -305,5 +305,5 @@ func (f RunAction) Stop(_ context.Context, state *RunState) (*action_kit_api.Sto
 		log.Debug().Str("runId", state.RunId).Msgf("Already stopped")
 	}
 
-	return &action_kit_api.StopResult{Messages: extutil.Ptr(messages)}, nil
+	return &action_kit_api.StopResult{Messages: new(messages)}, nil
 }

--- a/extgatlingenterprise/discovery.go
+++ b/extgatlingenterprise/discovery.go
@@ -10,7 +10,6 @@ import (
 	"github.com/steadybit/discovery-kit/go/discovery_kit_sdk"
 	"github.com/steadybit/extension-gatling/config"
 	"github.com/steadybit/extension-kit/extbuild"
-	"github.com/steadybit/extension-kit/extutil"
 	"time"
 )
 
@@ -37,7 +36,7 @@ func (d *gatlingEnterpriseSimulationDiscovery) Describe() discovery_kit_api.Disc
 	return discovery_kit_api.DiscoveryDescription{
 		Id: targetType,
 		Discover: discovery_kit_api.DescribingEndpointReferenceWithCallInterval{
-			CallInterval: extutil.Ptr("1m"),
+			CallInterval: new("1m"),
 		},
 	}
 }
@@ -46,9 +45,9 @@ func (d *gatlingEnterpriseSimulationDiscovery) DescribeTarget() discovery_kit_ap
 	return discovery_kit_api.TargetDescription{
 		Id:       targetType,
 		Label:    discovery_kit_api.PluralLabel{One: "Gatling Enterprise Simulation", Other: "Gatling Enterprise Simulations"},
-		Category: extutil.Ptr("Gatling"),
+		Category: new("Gatling"),
 		Version:  extbuild.GetSemverVersionStringOrUnknown(),
-		Icon:     extutil.Ptr(targetIcon),
+		Icon:     new(targetIcon),
 
 		Table: discovery_kit_api.Table{
 			Columns: []discovery_kit_api.Column{

--- a/extgatlingenterprise/simulations_api.go
+++ b/extgatlingenterprise/simulations_api.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/steadybit/extension-gatling/config"
 	"github.com/steadybit/extension-kit/extbuild"
-	"github.com/steadybit/extension-kit/extutil"
 	"io"
 	"net/http"
 	"net/url"
@@ -167,7 +166,7 @@ func RunSimulation(simulationId string, title string, description string, system
 
 	log.Info().Msgf("Successfully started simulation: %+v", result)
 
-	return extutil.Ptr(result.RunId), nil
+	return new(result.RunId), nil
 }
 
 func GetRun(runId string) (*GatlingRunResponse, error) {
@@ -218,7 +217,7 @@ func GetRun(runId string) (*GatlingRunResponse, error) {
 		return nil, err
 	}
 
-	return extutil.Ptr(result), nil
+	return new(result), nil
 }
 
 func getClient() *http.Client {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steadybit/extension-gatling
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
## Summary
- Bump Go to 1.26.2 in go.mod, ci.yml, and Dockerfile
- Apply `go fix ./...` changes