### PR TITLE
chore: update gatling to 3.15.1

### DIFF
--- a/.trivyignore.yml
+++ b/.trivyignore.yml
@@ -56,3 +56,15 @@ vulnerabilities:
   - id: CVE-2023-45853
     statement: Wait for upstream fix in debian
     expired_at: 2026-09-01
+  - id: CVE-2026-44249
+    statement: Wait for upstream netty fix
+    expired_at: 2026-09-01
+  - id: CVE-2026-47691
+    statement: Wait for upstream netty fix
+    expired_at: 2026-09-01
+  - id: CVE-2026-45674
+    statement: Wait for upstream netty fix
+    expired_at: 2026-09-01
+  - id: CVE-2026-45416
+    statement: Wait for upstream netty fix
+    expired_at: 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Update Gatling to 3.15.1 and gatling-maven-plugin to 4.21.7
+
 ## v1.0.45
 
 - Support discovery group attribute via `STEADYBIT_EXTENSION_DISCOVERY_GROUP` env var (or `discovery.group` Helm value) — when set, the extension adds `steadybit.group=<value>` to every discovered target

--- a/gatling-maven-scaffold/pom.xml
+++ b/gatling-maven-scaffold/pom.xml
@@ -10,8 +10,8 @@
 	<properties>
 		<maven.compiler.release>21</maven.compiler.release>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<gatling.version>3.15.0</gatling.version>
-		<gatling-maven-plugin.version>4.21.5</gatling-maven-plugin.version>
+		<gatling.version>3.15.1</gatling.version>
+		<gatling-maven-plugin.version>4.21.7</gatling-maven-plugin.version>
 		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
 		<maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
 		<maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>


### PR DESCRIPTION
## Summary
- Bump `gatling.version` to 3.15.1 and `gatling-maven-plugin.version` to 4.21.7 in `gatling-maven-scaffold/pom.xml`
- Ignore four new netty CVEs (CVE-2026-44249, CVE-2026-47691, CVE-2026-45674, CVE-2026-45416) in `.trivyignore.yml` pending upstream netty fix
- Add `(next)` section to the CHANGELOG

## Test plan
- [ ] CI green