### PR TITLE
docs: remove trivy-ignore bookkeeping from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## v1.0.46
 
-- chore: add CVE-2026-48959 and CVE-2026-45447 to trivyignore
-- chore: re-add CVE-2023-45853 to trivyignore
 - chore: update gatling to 3.15.1 and ignore new netty CVEs (#129)
 - chore: update to go 1.26.4
 - feat: add weekly auto patch-release workflow


### PR DESCRIPTION
Removes auto-generated trivy-ignore bookkeeping bullets from the most recent CHANGELOG entry. The auto patch-release workflow emitted these before the trivy-ignore filter landed in extension-kit; they don't represent user-visible changes.